### PR TITLE
Conditionally set source_path_size in the loaders and docs

### DIFF
--- a/pebblo_langchain/langchain_community/document_loaders/pebblo.py
+++ b/pebblo_langchain/langchain_community/document_loaders/pebblo.py
@@ -51,8 +51,13 @@ class PebbloSafeLoader(BaseLoader):
             "loader": loader_name,
             "source_path": self.source_path,
             "source_type": self.source_type,
-            "source_path_size": self.source_path_size,
+            **(
+                {"source_path_size": self.source_path_size}
+                if self.source_path_size is not None
+                else {}
+            ),
         }
+
         # generate app
         self.app = self._get_app_details()
         self._send_discover()
@@ -109,7 +114,11 @@ class PebbloSafeLoader(BaseLoader):
                     "source_path": doc_source_path,
                     "last_modified": doc.get("metadata", {}).get("last_modified"),
                     "file_owner": doc_source_owner,
-                    "source_path_size": doc_source_size,
+                    **(
+                        {"source_path_size": doc_source_size}
+                        if doc_source_size is not None
+                        else {}
+                    ),
                 }
             )
         payload = {
@@ -226,6 +235,8 @@ class PebbloSafeLoader(BaseLoader):
         return file_owner_name
 
     def get_source_size(self, source_path: str) -> int:
+        if not source_path:
+            return None
         size = None
         if os.path.isfile(source_path):
             size = os.path.getsize(source_path)


### PR DESCRIPTION
- Conditionally set source_path_size in the loaders and docs.
- Handle no source path in get_source_size.